### PR TITLE
GeoJSON Import to MapBox Style

### DIFF
--- a/app/src/main/java/io/ona/kujaku/exceptions/InvalidMapBoxStyleException.java
+++ b/app/src/main/java/io/ona/kujaku/exceptions/InvalidMapBoxStyleException.java
@@ -1,0 +1,13 @@
+package io.ona.kujaku.exceptions;
+
+/**
+ * Thrown when a MapBox style object is invalid or has missing required data.
+ *
+ * Created by Jason Rogena - jrogena@ona.io on 11/7/17.
+ */
+
+public class InvalidMapBoxStyleException extends Exception {
+    public InvalidMapBoxStyleException(String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/io/ona/kujaku/helpers/MapBoxStyleHelper.java
+++ b/app/src/main/java/io/ona/kujaku/helpers/MapBoxStyleHelper.java
@@ -1,0 +1,89 @@
+package io.ona.kujaku.helpers;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.ona.kujaku.exceptions.InvalidMapBoxStyleException;
+
+/**
+ * Helps manipulate the contents of a MapBox Style object.
+ * <p>
+ * See:
+ * https://www.mapbox.com/mapbox-gl-js/style-spec/
+ * <p>
+ * Created by Jason Rogena - jrogena@ona.io on 11/7/17.
+ * Created by Ephraim Kigamba - ekigamba@ona.io on 11/7/17/
+ */
+
+public class MapBoxStyleHelper {
+    private final JSONObject styleObject;
+
+    public MapBoxStyleHelper(JSONObject styleObject) {
+        this.styleObject = styleObject;
+    }
+
+    public boolean insertGeoJsonDataSource(@NonNull String sourceName, JSONObject geoJson, @NonNull String layerId)
+            throws JSONException, InvalidMapBoxStyleException {
+        if (styleObject != null && !TextUtils.isEmpty(sourceName)) {
+            JSONObject styleSources = new JSONObject();
+            if (styleObject.has("sources")) {
+                styleSources = styleObject.getJSONObject("sources");
+            }
+            styleSources.put(sourceName, geoJson);
+            styleObject.put("sources", styleSources);
+
+            return linkDataSourceToLayer(sourceName, layerId, null);
+        }
+
+        return false;
+    }
+
+    /**
+     * Links MapBox data-source to a pre-existing MapBox layer
+     *
+     * @param sourceName    Name of the MapBox datasource
+     * @param layerId       Id of the MapBox layer
+     * @param sourceLayer   Layer on the vector tile source to use
+     * @return  {@code TRUE} if able to associate the data-source with the layer
+     * @throws JSONException                If unable to parse the style object
+     * @throws InvalidMapBoxStyleException  If the style object has missing required components
+     */
+    public boolean linkDataSourceToLayer(@NonNull String sourceName, @NonNull String layerId, @Nullable String sourceLayer)
+            throws JSONException, InvalidMapBoxStyleException {
+        if (!TextUtils.isEmpty(sourceName) && !TextUtils.isEmpty(layerId) && styleObject != null) {
+            if (styleObject.has("layers")) {
+                JSONArray layers = styleObject.getJSONArray("layers");
+                for (int i = 0; i < layers.length(); i++) {
+                    JSONObject currentLayer = layers.getJSONObject(i);
+                    if (currentLayer.has("id") && !currentLayer.getString("id").isEmpty()) {
+                        if (layerId.equals(currentLayer.getString("id"))) {
+                            currentLayer.put("source", sourceName);
+                            if (TextUtils.isEmpty(sourceLayer) && currentLayer.has("source-layer")) {
+                                currentLayer.remove("source-layer");
+                            } else if (!TextUtils.isEmpty(sourceLayer)) {
+                                currentLayer.put("source-layer", sourceLayer);
+                            }
+
+                            return true;
+                        }
+                    } else {
+                        throw new InvalidMapBoxStyleException("Layer with no Id");
+                    }
+                }
+            } else {
+                throw new InvalidMapBoxStyleException("Provided style does not have layers");
+            }
+        }
+
+        return false;
+    }
+
+    public JSONObject getStyleObject() {
+        return styleObject;
+    }
+}

--- a/app/src/test/java/io/ona/kujaku/helpers/MapBoxStyleHelperTest.java
+++ b/app/src/test/java/io/ona/kujaku/helpers/MapBoxStyleHelperTest.java
@@ -1,0 +1,72 @@
+package io.ona.kujaku.helpers;
+
+import junit.framework.Assert;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import io.ona.kujaku.exceptions.InvalidMapBoxStyleException;
+
+/**
+ * Created by Jason Rogena - jrogena@ona.io on 11/7/17.
+ */
+
+public class MapBoxStyleHelperTest {
+    /**
+     * Tests best case for adding GeoJson data source to MapBox style
+     * 
+     * @throws JSONException
+     * @throws InvalidMapBoxStyleException
+     */
+    @Test
+    public void insertGeoJsonDataSource() throws JSONException, InvalidMapBoxStyleException {
+        JSONObject style = new JSONObject();
+        style.put("layers", new JSONArray());
+        JSONObject layer0 = new JSONObject();
+        String layerId = "layer0";
+        layer0.put("id", layerId);
+        style.getJSONArray("layers").put(layer0);
+        JSONObject layer1 = new JSONObject();
+        layer1.put("id", "layer1");
+        style.getJSONArray("layers").put(layer1);
+
+        JSONObject geoJsonDataSource = getGeoJsonDataSource();
+        String geoJsonSourceName = "geojson0";
+
+        MapBoxStyleHelper styleHelper = new MapBoxStyleHelper(style);
+        styleHelper.insertGeoJsonDataSource(geoJsonSourceName, geoJsonDataSource, layerId);
+        JSONObject returnedData = styleHelper.getStyleObject();
+
+        Assert.assertTrue(returnedData.has("sources"));
+        Assert.assertTrue(returnedData.getJSONObject("sources").has(geoJsonSourceName));
+        Assert.assertEquals(returnedData.getJSONObject("sources").getJSONObject(geoJsonSourceName),
+                getGeoJsonDataSource());
+        Assert.assertTrue(returnedData.getJSONArray("layers").getJSONObject(0).has("source"));
+        Assert.assertTrue(returnedData.getJSONArray("layers").getJSONObject(0).getString("source").equals(geoJsonSourceName));
+    }
+
+    private JSONObject getGeoJsonDataSource() throws JSONException {
+        return new JSONObject("{\n" +
+                "    \"type\": \"geojson\",\n" +
+                "    \"data\": {\n" +
+                "        \"features\": [\n" +
+                "            {\n" +
+                "              \"type\": \"Feature\",\n" +
+                "              \"properties\": {},\n" +
+                "              \"geometry\": {\n" +
+                "                \"coordinates\": [\n" +
+                "                  36.791183,\n" +
+                "                  -1.293522\n" +
+                "                ],\n" +
+                "                \"type\": \"Point\"\n" +
+                "              },\n" +
+                "              \"id\": \"b3369aa6b5022be641198d898bd20e47\"\n" +
+                "            }\n" +
+                "          ],\n" +
+                "        \"type\": \"FeatureCollection\"\n" +
+                "  }\n" +
+                "}");
+    }
+}

--- a/app/src/test/java/io/ona/kujaku/helpers/MapBoxStyleHelperTest.java
+++ b/app/src/test/java/io/ona/kujaku/helpers/MapBoxStyleHelperTest.java
@@ -6,13 +6,19 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+import io.ona.kujaku.BuildConfig;
 import io.ona.kujaku.exceptions.InvalidMapBoxStyleException;
 
 /**
  * Created by Jason Rogena - jrogena@ona.io on 11/7/17.
  */
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, manifest = Config.NONE)
 public class MapBoxStyleHelperTest {
     /**
      * Tests best case for adding GeoJson data source to MapBox style
@@ -41,8 +47,8 @@ public class MapBoxStyleHelperTest {
 
         Assert.assertTrue(returnedData.has("sources"));
         Assert.assertTrue(returnedData.getJSONObject("sources").has(geoJsonSourceName));
-        Assert.assertEquals(returnedData.getJSONObject("sources").getJSONObject(geoJsonSourceName),
-                getGeoJsonDataSource());
+        Assert.assertEquals(returnedData.getJSONObject("sources").getJSONObject(geoJsonSourceName).toString(),
+                getGeoJsonDataSource().toString());
         Assert.assertTrue(returnedData.getJSONArray("layers").getJSONObject(0).has("source"));
         Assert.assertTrue(returnedData.getJSONArray("layers").getJSONObject(0).getString("source").equals(geoJsonSourceName));
     }


### PR DESCRIPTION
Adds classes for manipulating MapBox's style objects. Caters for importing GeoJSON data sources to a style object.

Closes #3 