### PR TITLE
Enable updating offline map bounds

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'realm-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '0.2.5'
+version '0.2.5-25-1'
 project.version = this.version
 
 task sourceJar(type: Jar) {

--- a/library/src/androidTest/java/io/ona/kujaku/data/realm/MapBoxDeleteTaskInstrumentedTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/data/realm/MapBoxDeleteTaskInstrumentedTest.java
@@ -38,7 +38,7 @@ public class MapBoxDeleteTaskInstrumentedTest extends RealmRelatedInstrumentedTe
         MapBoxOfflineQueueTask queryResultTask = realm.where(MapBoxOfflineQueueTask.class)
                 .contains("task", mapboxAccessToken)
                 .contains("task", mapName)
-                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE)
+                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED)
                 .equalTo("taskType", MapBoxOfflineQueueTask.TASK_TYPE_DELETE)
                 .findFirst();
 

--- a/library/src/androidTest/java/io/ona/kujaku/data/realm/MapBoxDownloadTaskInstrumentedTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/data/realm/MapBoxDownloadTaskInstrumentedTest.java
@@ -53,7 +53,7 @@ public class MapBoxDownloadTaskInstrumentedTest extends RealmRelatedInstrumented
 
         MapBoxOfflineQueueTask queryResultTask = realm.where(MapBoxOfflineQueueTask.class)
                 .contains("task", mapName)
-                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE)
+                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED)
                 .equalTo("taskType", MapBoxOfflineQueueTask.TASK_TYPE_DOWNLOAD)
                 .findFirst();
 

--- a/library/src/androidTest/java/io/ona/kujaku/data/realm/RealmDatabaseTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/data/realm/RealmDatabaseTest.java
@@ -97,7 +97,7 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
         MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
         addedRecords.add(MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask));
 
-        MapBoxDeleteTask mapBoxDeleteTask = new MapBoxDeleteTask(deleteMapName, BuildConfig.MAPBOX_SDK_ACCESS_TOKEN);
+        MapBoxDeleteTask mapBoxDeleteTask = new MapBoxDeleteTask(deleteMapName, sampleMapBoxStyleURL);
         addedRecords.add(MapBoxDeleteTask.constructMapBoxOfflineQueueTask(mapBoxDeleteTask));
 
         assertFalse(realmDatabase.deleteTask(downloadMapName, false));
@@ -113,7 +113,7 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
         MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
         MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask);
 
-        MapBoxDeleteTask mapBoxDeleteTask = new MapBoxDeleteTask(deleteMapName, BuildConfig.MAPBOX_SDK_ACCESS_TOKEN);
+        MapBoxDeleteTask mapBoxDeleteTask = new MapBoxDeleteTask(deleteMapName, sampleMapBoxStyleURL);
         MapBoxDeleteTask.constructMapBoxOfflineQueueTask(mapBoxDeleteTask);
 
         assertTrue(realmDatabase.deleteTask(downloadMapName, true));
@@ -158,7 +158,6 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
         RealmDatabase realmDatabase = RealmDatabase.init(context);
 
         String downloadMapName = UUID.randomUUID().toString();
-        String downloadMapName2 = UUID.randomUUID().toString();
 
         MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
         MapBoxOfflineQueueTask mapBoxOfflineQueueTask = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask);
@@ -187,13 +186,17 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
         MapBoxOfflineQueueTask mapBoxOfflineQueueTask1 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask1);
 
         MapBoxDownloadTask mapBoxDownloadTask2 = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
-        MapBoxOfflineQueueTask mapBoxOfflineQueueTask2 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask1);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask2 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask2);
+
+        MapBoxDownloadTask mapBoxDownloadTask3 = createSampleDownloadTask("kl", "Market curve", sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask3 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask3);
 
         realmDatabase.persistDownloadStartedStatus(mapBoxOfflineQueueTask1);
 
         addedRecords.add(mapBoxOfflineQueueTask);
         addedRecords.add(mapBoxOfflineQueueTask1);
         addedRecords.add(mapBoxOfflineQueueTask2);
+        addedRecords.add(mapBoxOfflineQueueTask3);
 
         String id1 = mapBoxOfflineQueueTask.getId();
         String id2 = mapBoxOfflineQueueTask2.getId();
@@ -214,9 +217,11 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
 
         realmResults = realm.where(MapBoxOfflineQueueTask.class)
                 .equalTo("id", mapBoxOfflineQueueTask1.getId())
+                .or()
+                .equalTo("id", mapBoxOfflineQueueTask3.getId())
                 .findAll();
 
-        assertEquals(1, realmResults.size());
+        assertEquals(2, realmResults.size());
     }
 
     /*
@@ -243,7 +248,7 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
                         -17.875469,
                         25.876589
                 ),
-                BuildConfig.MAPBOX_SDK_ACCESS_TOKEN
+                sampleMapBoxStyleURL
         );
     }
 }

--- a/library/src/androidTest/java/io/ona/kujaku/data/realm/RealmDatabaseTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/data/realm/RealmDatabaseTest.java
@@ -1,23 +1,11 @@
 package io.ona.kujaku.data.realm;
 
-import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
-
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.UUID;
-import java.util.logging.Logger;
 
-import io.ona.kujaku.BuildConfig;
 import io.ona.kujaku.data.MapBoxDeleteTask;
 import io.ona.kujaku.data.MapBoxDownloadTask;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;

--- a/library/src/androidTest/java/io/ona/kujaku/data/realm/RealmDatabaseTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/data/realm/RealmDatabaseTest.java
@@ -1,6 +1,7 @@
 package io.ona.kujaku.data.realm;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -22,6 +23,7 @@ import io.ona.kujaku.data.MapBoxDownloadTask;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
+import io.realm.RealmResults;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -119,6 +121,102 @@ public class RealmDatabaseTest extends RealmRelatedInstrumentedTest {
 
         assertTrue(realmDatabase.deleteTask(deleteMapName, false));
         assertFalse(realmDatabase.deleteTask(deleteMapName, false));
+    }
+
+    @Test
+    public void persistCompletedStatus() {
+        RealmDatabase realmDatabase = RealmDatabase.init(context);
+
+        String downloadMapName = UUID.randomUUID().toString();
+
+        MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask);
+        addedRecords.add(mapBoxOfflineQueueTask);
+
+        realmDatabase.persistCompletedStatus(mapBoxOfflineQueueTask);
+
+        assertEquals(MapBoxOfflineQueueTask.TASK_STATUS_DONE, mapBoxOfflineQueueTask.getTaskStatus());
+    }
+
+    @Test
+    public void persistDownloadStartedStatus() {
+        RealmDatabase realmDatabase = RealmDatabase.init(context);
+
+        String downloadMapName = UUID.randomUUID().toString();
+
+        MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask);
+        addedRecords.add(mapBoxOfflineQueueTask);
+
+        realmDatabase.persistDownloadStartedStatus(mapBoxOfflineQueueTask);
+
+        assertEquals(MapBoxOfflineQueueTask.TASK_STATUS_STARTED, mapBoxOfflineQueueTask.getTaskStatus());
+    }
+
+    @Test
+    public void getPendingOfflineMapDownloadsWithSimilarNames() {
+        RealmDatabase realmDatabase = RealmDatabase.init(context);
+
+        String downloadMapName = UUID.randomUUID().toString();
+        String downloadMapName2 = UUID.randomUUID().toString();
+
+        MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask);
+
+        MapBoxDownloadTask mapBoxDownloadTask1 = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask1 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask1);
+
+        addedRecords.add(mapBoxOfflineQueueTask);
+        addedRecords.add(mapBoxOfflineQueueTask1);
+
+        RealmResults<MapBoxOfflineQueueTask> realmResults = realmDatabase.getPendingOfflineMapDownloadsWithSimilarNames(downloadMapName);
+
+        assertEquals(2, realmResults.size());
+    }
+
+    @Test
+    public void deletePendingOfflineMapDownloadsWithSimilarNames() {
+        RealmDatabase realmDatabase = RealmDatabase.init(context);
+
+        String downloadMapName = UUID.randomUUID().toString();
+
+        MapBoxDownloadTask mapBoxDownloadTask = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask);
+
+        MapBoxDownloadTask mapBoxDownloadTask1 = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask1 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask1);
+
+        MapBoxDownloadTask mapBoxDownloadTask2 = createSampleDownloadTask("kl", downloadMapName, sampleMapBoxStyleURL);
+        MapBoxOfflineQueueTask mapBoxOfflineQueueTask2 = MapBoxDownloadTask.constructMapBoxOfflineQueueTask(mapBoxDownloadTask1);
+
+        realmDatabase.persistDownloadStartedStatus(mapBoxOfflineQueueTask1);
+
+        addedRecords.add(mapBoxOfflineQueueTask);
+        addedRecords.add(mapBoxOfflineQueueTask1);
+        addedRecords.add(mapBoxOfflineQueueTask2);
+
+        String id1 = mapBoxOfflineQueueTask.getId();
+        String id2 = mapBoxOfflineQueueTask2.getId();
+
+        boolean isDeleted = realmDatabase.deletePendingOfflineMapDownloadsWithSimilarNames(downloadMapName);
+
+        assertTrue(isDeleted);
+
+        Realm realm = Realm.getDefaultInstance();
+
+        RealmResults<MapBoxOfflineQueueTask> realmResults = realm.where(MapBoxOfflineQueueTask.class)
+                .equalTo("id", id1)
+                .or()
+                .equalTo("id", id2)
+                .findAll();
+
+        assertEquals(0, realmResults.size());
+
+        realmResults = realm.where(MapBoxOfflineQueueTask.class)
+                .equalTo("id", mapBoxOfflineQueueTask1.getId())
+                .findAll();
+
+        assertEquals(1, realmResults.size());
     }
 
     /*

--- a/library/src/androidTest/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloaderTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloaderTest.java
@@ -673,8 +673,4 @@ public class MapBoxOfflineResourcesDownloaderTest {
         return lastId++;
     }
 
-    private int getRandomInt(int upperLimit) {
-        return (int) (Math.random() * upperLimit);
-    }
-
 }

--- a/library/src/androidTest/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceInstrumentedTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceInstrumentedTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 import io.ona.kujaku.BuildConfig;
+import io.ona.kujaku.data.realm.RealmDatabase;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
 import io.realm.Realm;
 import utils.Constants;
@@ -101,6 +102,9 @@ public class MapboxOfflineDownloaderServiceInstrumentedTest {
         sampleServiceIntent = createSampleDownloadIntent(sampleServiceIntent);
 
         String mapName = sampleServiceIntent.getStringExtra(Constants.PARCELABLE_KEY_MAP_UNIQUE_NAME);
+
+        RealmDatabase realmDatabase = RealmDatabase.init(context);
+        insertValueInPrivateField(mapboxOfflineDownloaderService, "realmDatabase", realmDatabase);
 
         mapboxOfflineDownloaderService.persistOfflineMapTask(sampleServiceIntent);
 

--- a/library/src/androidTest/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceInstrumentedTest.java
+++ b/library/src/androidTest/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceInstrumentedTest.java
@@ -230,7 +230,7 @@ public class MapboxOfflineDownloaderServiceInstrumentedTest {
         Realm realm = Realm.getDefaultInstance();
 
         MapBoxOfflineQueueTask mapBoxOfflineQueueTask = realm.where(MapBoxOfflineQueueTask.class)
-                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE)
+                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED)
                 .contains("task", mapName)
                 .findFirst();
 

--- a/library/src/main/java/io/ona/kujaku/data/MapBoxDeleteTask.java
+++ b/library/src/main/java/io/ona/kujaku/data/MapBoxDeleteTask.java
@@ -82,7 +82,7 @@ public class MapBoxDeleteTask {
 
     /**
      * Creates a valid {@link MapBoxOfflineQueueTask} given a {@link MapBoxDeleteTask} with default
-     * {@link MapBoxOfflineQueueTask#taskStatus} as {@link MapBoxOfflineQueueTask#TASK_STATUS_INCOMPLETE}
+     * {@link MapBoxOfflineQueueTask#taskStatus} as {@link MapBoxOfflineQueueTask#TASK_STATUS_NOT_STARTED}
      * of type {@link MapBoxOfflineQueueTask#TASK_TYPE_DELETE}
      *
      * @param mapBoxDeleteTask
@@ -97,7 +97,7 @@ public class MapBoxDeleteTask {
             mapBoxOfflineQueueTask.setDateCreated(new Date());
             mapBoxOfflineQueueTask.setDateUpdated(new Date());
             mapBoxOfflineQueueTask.setTask(mapBoxDeleteTask.getJSONObject());
-            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE);
+            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED);
             mapBoxOfflineQueueTask.setTaskType(MapBoxOfflineQueueTask.TASK_TYPE_DELETE);
 
             realm.commitTransaction();

--- a/library/src/main/java/io/ona/kujaku/data/MapBoxDownloadTask.java
+++ b/library/src/main/java/io/ona/kujaku/data/MapBoxDownloadTask.java
@@ -206,7 +206,7 @@ public class MapBoxDownloadTask {
 
     /**
      * Creates a valid {@link MapBoxOfflineQueueTask} given a {@link MapBoxDownloadTask} with default
-     * {@link MapBoxOfflineQueueTask#taskStatus} = {@link MapBoxOfflineQueueTask#TASK_STATUS_INCOMPLETE}
+     * {@link MapBoxOfflineQueueTask#taskStatus} = {@link MapBoxOfflineQueueTask#TASK_STATUS_NOT_STARTED}
      * & adds it to the queue
      *
      * @param mapBoxDownloadTask to add to the queue
@@ -222,7 +222,7 @@ public class MapBoxDownloadTask {
             mapBoxOfflineQueueTask.setDateCreated(new Date());
             mapBoxOfflineQueueTask.setDateUpdated(new Date());
             mapBoxOfflineQueueTask.setTask(mapBoxDownloadTask.getJSONObject());
-            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE);
+            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED);
             mapBoxOfflineQueueTask.setTaskType(MapBoxOfflineQueueTask.TASK_TYPE_DOWNLOAD);
 
             realm.commitTransaction();

--- a/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
+++ b/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
@@ -3,6 +3,8 @@ package io.ona.kujaku.data.realm;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
+import com.mapbox.mapboxsdk.offline.OfflineRegion;
+
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
@@ -11,7 +13,6 @@ import io.realm.RealmResults;
 /**
  * Created by Jason Rogena - jrogena@ona.io on 11/20/17.
  */
-
 public class RealmDatabase {
     protected static final long VERSION = 1l;
     protected static final String NAME = "kujaku.realm";
@@ -59,6 +60,42 @@ public class RealmDatabase {
         }
     }
 
+    /**
+     * Saves a {@link MapBoxOfflineQueueTask} as {@link MapBoxOfflineQueueTask#TASK_STATUS_DONE}<br/>
+     * This means the {@link OfflineRegion} can no longer be resumed if it was incomplete.<br/>
+     * This also means that a {@link OfflineRegion} will still be in storage if it was not successfully deleted
+     *
+     * @param mapBoxOfflineQueueTask
+     */
+    public void persistCompletedStatus(@NonNull MapBoxOfflineQueueTask mapBoxOfflineQueueTask) {
+        Realm realm = Realm.getDefaultInstance();
+        realm.beginTransaction();
+
+        mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_DONE);
+        realm.commitTransaction();
+    }
+
+    /**
+     * Updates the {@link MapBoxOfflineQueueTask} status as {@link MapBoxOfflineQueueTask#TASK_STATUS_NOT_STARTED}<br/>
+     * This means that subsequent Offline Region download calls with a similar map name will not result in this task being deleted.
+     *
+     * @param mapBoxOfflineQueueTask
+     */
+    public void persistDownloadStartedStatus(@NonNull MapBoxOfflineQueueTask mapBoxOfflineQueueTask) {
+        Realm realm = Realm.getDefaultInstance();
+        realm.beginTransaction();
+        mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_STARTED);
+
+        realm.commitTransaction();
+    }
+
+    /**
+     * Retrieves the {@link MapBoxOfflineQueueTask}s of type {@link MapBoxOfflineQueueTask#TASK_TYPE_DOWNLOAD}
+     * which are pending i.e. their downloads have not started. Their status is {@link MapBoxOfflineQueueTask#TASK_STATUS_NOT_STARTED}
+     *
+     * @param mapName
+     * @return
+     */
     protected RealmResults<MapBoxOfflineQueueTask> getPendingOfflineMapDownloadsWithSimilarNames(String mapName) {
         Realm realm = Realm.getDefaultInstance();
 
@@ -70,6 +107,13 @@ public class RealmDatabase {
         return mapBoxOfflineQueueTaskRealmResults;
     }
 
+    /**
+     * Deletes all {@link MapBoxOfflineQueueTask}s of type {@link MapBoxOfflineQueueTask#TASK_TYPE_DOWNLOAD}
+     * whose download has not started
+     *
+     * @param mapName
+     * @return
+     */
     public boolean deletePendingOfflineMapDownloadsWithSimilarNames(String mapName) {
         RealmResults<MapBoxOfflineQueueTask> realmResults = getPendingOfflineMapDownloadsWithSimilarNames(mapName);
 

--- a/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
+++ b/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
@@ -3,10 +3,10 @@ package io.ona.kujaku.data.realm;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import io.ona.kujaku.data.MapBoxDownloadTask;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
+import io.realm.RealmResults;
 
 /**
  * Created by Jason Rogena - jrogena@ona.io on 11/20/17.
@@ -57,5 +57,29 @@ public class RealmDatabase {
         } else {
             return false;
         }
+    }
+
+    protected RealmResults<MapBoxOfflineQueueTask> getPendingOfflineMapDownloadsWithSimilarNames(String mapName) {
+        Realm realm = Realm.getDefaultInstance();
+
+        RealmResults<MapBoxOfflineQueueTask> mapBoxOfflineQueueTaskRealmResults = realm.where(MapBoxOfflineQueueTask.class)
+                .equalTo("taskType", MapBoxOfflineQueueTask.TASK_TYPE_DOWNLOAD)
+                .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED)
+                .findAll();
+
+        return mapBoxOfflineQueueTaskRealmResults;
+    }
+
+    public boolean deletePendingOfflineMapDownloadsWithSimilarNames(String mapName) {
+        RealmResults<MapBoxOfflineQueueTask> realmResults = getPendingOfflineMapDownloadsWithSimilarNames(mapName);
+
+        Realm realm = Realm.getDefaultInstance();
+        realm.beginTransaction();
+
+        boolean isDeleted = realmResults.deleteAllFromRealm();
+
+        realm.commitTransaction();
+
+        return isDeleted;
     }
 }

--- a/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
+++ b/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
@@ -2,6 +2,7 @@ package io.ona.kujaku.data.realm;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.offline.OfflineRegion;
 
@@ -114,7 +115,11 @@ public class RealmDatabase {
      * @param mapName
      * @return
      */
-    public boolean deletePendingOfflineMapDownloadsWithSimilarNames(String mapName) {
+    public boolean deletePendingOfflineMapDownloadsWithSimilarNames(@Nullable String mapName) {
+        if (mapName == null) {
+            return false;
+        }
+
         RealmResults<MapBoxOfflineQueueTask> realmResults = getPendingOfflineMapDownloadsWithSimilarNames(mapName);
 
         Realm realm = Realm.getDefaultInstance();

--- a/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
+++ b/library/src/main/java/io/ona/kujaku/data/realm/RealmDatabase.java
@@ -45,7 +45,7 @@ public class RealmDatabase {
 
         taskToDelete = realm.where(MapBoxOfflineQueueTask.class)
                 .equalTo("taskType", taskType)
-                .contains("task", mapName)
+                .contains("task", "\"mapName\":\"" + mapName + "\"")
                 .findFirst();
 
         if (taskToDelete != null) {
@@ -103,6 +103,7 @@ public class RealmDatabase {
         RealmResults<MapBoxOfflineQueueTask> mapBoxOfflineQueueTaskRealmResults = realm.where(MapBoxOfflineQueueTask.class)
                 .equalTo("taskType", MapBoxOfflineQueueTask.TASK_TYPE_DOWNLOAD)
                 .equalTo("taskStatus", MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED)
+                .contains("task", "\"mapName\":\"" + mapName + "\"")
                 .findAll();
 
         return mapBoxOfflineQueueTaskRealmResults;

--- a/library/src/main/java/io/ona/kujaku/data/realm/objects/MapBoxOfflineQueueTask.java
+++ b/library/src/main/java/io/ona/kujaku/data/realm/objects/MapBoxOfflineQueueTask.java
@@ -21,7 +21,8 @@ public class MapBoxOfflineQueueTask extends RealmObject {
             , TASK_TYPE_DELETE = "TASK TYPE DELETE";
 
     public static final int TASK_STATUS_DONE = 1
-            , TASK_STATUS_INCOMPLETE = 2;
+            , TASK_STATUS_NOT_STARTED = 2
+            , TASK_STATUS_STARTED = 3;
 
     @PrimaryKey
     private String id = UUID.randomUUID().toString();

--- a/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
+++ b/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
@@ -558,14 +558,14 @@ public class MapBoxOfflineResourcesDownloader {
      * Deletes previously downloaded {@link OfflineRegion} with the given map name and excludes the one with the given ID
      *
      * @param mapName
-     * @param currentMapDownloadId
+     * @param mapIdToExclude
      */
-    public void deletePreviousOfflineMapDownloads(final String mapName, final long currentMapDownloadId) {
+    public void deletePreviousOfflineMapDownloads(final String mapName, final long mapIdToExclude) {
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
             @Override
             public void onList(OfflineRegion[] offlineRegions) {
                 for (OfflineRegion offlineRegion : offlineRegions) {
-                    if (offlineRegion.getID() != currentMapDownloadId) {
+                    if (offlineRegion.getID() != mapIdToExclude) {
                         try {
                             String json = new String(offlineRegion.getMetadata(), MapBoxOfflineResourcesDownloader.JSON_CHARSET);
                             JSONObject jsonObject = new JSONObject(json);

--- a/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
+++ b/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
@@ -29,17 +29,16 @@ import utils.exceptions.MalformedDataException;
 import utils.exceptions.OfflineMapDownloadException;
 
 /**
- *
  * This is a singleton
- *
+ * <p>
  * Basically wraps around the MapBox OfflineManager & enables:
- *  - Downloading a map for offline
- *  - Pausing a download
- *  - Resuming download
- *  - Deleting an offline map
- *  - Getting the map status {@link com.mapbox.mapboxsdk.offline.OfflineRegionStatus}
- *
- *
+ * - Downloading a map for offline
+ * - Pausing a download
+ * - Resuming download
+ * - Deleting an offline map
+ * - Getting the map status {@link com.mapbox.mapboxsdk.offline.OfflineRegionStatus}
+ * <p>
+ * <p>
  * Created by Ephraim Kigamba - ekigamba@ona.io on 10/11/2017.
  */
 public class MapBoxOfflineResourcesDownloader {
@@ -79,13 +78,12 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Basically downloads/queues the map for download
      *
-     * @param mapBoxOfflineQueueTask    The {@link MapBoxOfflineQueueTask} object holding info on the MapBox style to download
-     * @param onDownloadMapListener     {@link OnDownloadMapListener} to provide updates/errors during MapDownload
-     *
+     * @param mapBoxOfflineQueueTask The {@link MapBoxOfflineQueueTask} object holding info on the MapBox style to download
+     * @param onDownloadMapListener  {@link OnDownloadMapListener} to provide updates/errors during MapDownload
      * @throws OfflineMapDownloadException In case - {@code name} is {@code NULL} or empty, already used by another offline map (not unique)
-     *                                             - {@code styleUrl} is invalid - {@code NULL}, empty OR not a MapBox url i.e. in the form mapbox://
-     *                                             - {@code minZoom} is invalid - Greater than maxZoom, not among 0-22
-     *                                             - {@code maxZoom} is invalid - Lower than minZoom, not among 0-22
+     *                                     - {@code styleUrl} is invalid - {@code NULL}, empty OR not a MapBox url i.e. in the form mapbox://
+     *                                     - {@code minZoom} is invalid - Greater than maxZoom, not among 0-22
+     *                                     - {@code maxZoom} is invalid - Lower than minZoom, not among 0-22
      */
     public void downloadMap(@NonNull MapBoxOfflineQueueTask mapBoxOfflineQueueTask, OnDownloadMapListener onDownloadMapListener)
             throws MalformedDataException
@@ -100,11 +98,10 @@ public class MapBoxOfflineResourcesDownloader {
      *
      * @param mapBoxDownloadTask    The {@link MapBoxDownloadTask} object holding info on the MapBox style to download
      * @param onDownloadMapListener {@link OnDownloadMapListener} to provide updates/errors during MapDownload
-     *
      * @throws OfflineMapDownloadException In case - {@code name} is {@code NULL} or empty, already used by another offline map (not unique)
-     *                                             - {@code styleUrl} is invalid - {@code NULL}, empty OR not a MapBox url i.e. in the form mapbox://
-     *                                             - {@code minZoom} is invalid - Greater than maxZoom, not among 0-22
-     *                                             - {@code maxZoom} is invalid - Lower than minZoom, not among 0-22
+     *                                     - {@code styleUrl} is invalid - {@code NULL}, empty OR not a MapBox url i.e. in the form mapbox://
+     *                                     - {@code minZoom} is invalid - Greater than maxZoom, not among 0-22
+     *                                     - {@code maxZoom} is invalid - Lower than minZoom, not among 0-22
      */
     public void downloadMap(@NonNull MapBoxDownloadTask mapBoxDownloadTask, OnDownloadMapListener onDownloadMapListener)
             throws OfflineMapDownloadException {
@@ -120,22 +117,19 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Basically downloads/queues the map for download
      *
-     *
-     *
-     * @param name Unique name of the map
-     * @param styleUrl The Style URL on MapBox
-     * @param topLeftBound The top-left coordinate of the map
-     * @param bottomRightBound The bottom-right coordinate of the map
-     * @param minZoom The min-zoom of the map i.e among 0-22
-     * @param maxZoom The max-zoom of the map i.e. among 0-22. This should be greater than the {@code minZoom}
+     * @param name                  Unique name of the map
+     * @param styleUrl              The Style URL on MapBox
+     * @param topLeftBound          The top-left coordinate of the map
+     * @param bottomRightBound      The bottom-right coordinate of the map
+     * @param minZoom               The min-zoom of the map i.e among 0-22
+     * @param maxZoom               The max-zoom of the map i.e. among 0-22. This should be greater than the {@code minZoom}
      * @param onDownloadMapListener {@link OnDownloadMapListener} to provide updates/errors during MapDownload
-     *
      * @throws OfflineMapDownloadException In case - {@code name} is {@code NULL} or empty, already used by another offline map (not unique)
-     *                                             - {@code styleUrl} is invalid - {@code NULL}, empty OR not a MapBox url i.e. in the form mapbox://
-     *                                             - {@code minZoom} is invalid - Greater than maxZoom, not among 0-22
-     *                                             - {@code maxZoom} is invalid - Lower than minZoom, not among 0-22
+     *                                     - {@code styleUrl} is invalid - {@code NULL}, empty OR not a MapBox url i.e. in the form mapbox://
+     *                                     - {@code minZoom} is invalid - Greater than maxZoom, not among 0-22
+     *                                     - {@code maxZoom} is invalid - Lower than minZoom, not among 0-22
      */
-    private void downloadMap(final String name, final String styleUrl,@NonNull final LatLng topLeftBound,@NonNull final LatLng bottomRightBound, final double minZoom, final double maxZoom, final OnDownloadMapListener onDownloadMapListener)
+    private void downloadMap(final String name, final String styleUrl, @NonNull final LatLng topLeftBound, @NonNull final LatLng bottomRightBound, final double minZoom, final double maxZoom, final OnDownloadMapListener onDownloadMapListener)
             throws OfflineMapDownloadException {
         if (offlineManager == null) {
             throw new OfflineMapDownloadException("Context passed is null");
@@ -215,8 +209,7 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Deletes a specific offline map given the name
      *
-     *
-     * @param name Unique name of the map
+     * @param name                        Unique name of the map
      * @param offlineRegionDeleteCallback Callback in case the operation is SUCCESS or FAILURE {@see com.mapbox.mapboxsdk.offline.OfflineRegion.OfflineRegionDeleteCallback}
      *                                    Fails if the offline map with the give {@code name} does not exist
      */
@@ -250,7 +243,7 @@ public class MapBoxOfflineResourcesDownloader {
 
                         @Override
                         public void onError(String error) {
-                            Log.e(TAG, "ON DELETE MAP : " + name + " --> "+ error);
+                            Log.e(TAG, "ON DELETE MAP : " + name + " --> " + error);
                         }
                     };
                 } else {
@@ -272,7 +265,7 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Resumes download of an Offline map with the given name
      *
-     * @param name Unique name of the map
+     * @param name                  Unique name of the map
      * @param onDownloadMapListener Callback to give updates on download progress or errors
      */
     public void resumeMapDownload(@NonNull final String name, final OnDownloadMapListener onDownloadMapListener) {
@@ -339,7 +332,7 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Resumes download of an Offline map given the name
      *
-     * @param offlineRegion {@link OfflineRegion} to resume download
+     * @param offlineRegion         {@link OfflineRegion} to resume download
      * @param onDownloadMapListener {@link OnDownloadMapListener} Callback to receive map download updates or error description
      */
     public void resumeMapDownload(@NonNull final OfflineRegion offlineRegion, final OnDownloadMapListener onDownloadMapListener) {
@@ -386,7 +379,7 @@ public class MapBoxOfflineResourcesDownloader {
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
             @Override
             public void onList(OfflineRegion[] offlineRegions) {
-                for(final OfflineRegion offlineRegion: offlineRegions) {
+                for (final OfflineRegion offlineRegion : offlineRegions) {
                     offlineRegion.getStatus(new OfflineRegion.OfflineRegionStatusCallback() {
                         @Override
                         public void onStatus(OfflineRegionStatus status) {
@@ -414,7 +407,8 @@ public class MapBoxOfflineResourcesDownloader {
 
     /**
      * Pauses a map download
-     * @param name Unique name of the map
+     *
+     * @param name                       Unique name of the map
      * @param onPauseMapDownloadCallback Callback which is called in case the operation is a SUCCESS or FAILURE
      */
     public void pauseMapDownload(@NonNull final String name, final OnPauseMapDownloadCallback onPauseMapDownloadCallback) {
@@ -483,7 +477,7 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Retrieves an Offline Map's status {@see OfflineRegionStatus}
      *
-     * @param name Unique name of the map
+     * @param name                        Unique name of the map
      * @param offlineRegionStatusCallback Callback called when map status is retrieved or the operation FAILS
      */
     public void getMapStatus(@NonNull final String name, final OfflineRegionStatusCallback offlineRegionStatusCallback) {
@@ -534,12 +528,12 @@ public class MapBoxOfflineResourcesDownloader {
     /**
      * Matches a given map name to an OfflineRegion given the OfflineRegions
      *
-     * @param name Unique name of the map
+     * @param name           Unique name of the map
      * @param offlineRegions OfflineRegions returned from {@link OfflineManager#listOfflineRegions(OfflineManager.ListOfflineRegionsCallback)}
      * @return {@link OfflineRegion} with the given name
      */
-    private OfflineRegion getOfflineRegion(@NonNull String name,@NonNull OfflineRegion[] offlineRegions) {
-        for (OfflineRegion offlineRegion: offlineRegions) {
+    private OfflineRegion getOfflineRegion(@NonNull String name, @NonNull OfflineRegion[] offlineRegions) {
+        for (OfflineRegion offlineRegion : offlineRegions) {
             try {
                 String json = new String(offlineRegion.getMetadata(), JSON_CHARSET);
                 JSONObject jsonObject = new JSONObject(json);
@@ -560,8 +554,51 @@ public class MapBoxOfflineResourcesDownloader {
         return null;
     }
 
-    public OfflineManager getOfflineManager() {
-        return offlineManager;
+    /**
+     * Deletes previously downloaded {@link OfflineRegion} with the given map name and excludes the one with the given ID
+     *
+     * @param mapName
+     * @param currentMapDownloadId
+     */
+    public void deletePreviousOfflineMapDownloads(final String mapName, final long currentMapDownloadId) {
+        offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
+            @Override
+            public void onList(OfflineRegion[] offlineRegions) {
+                for (OfflineRegion offlineRegion : offlineRegions) {
+                    if (offlineRegion.getID() != currentMapDownloadId) {
+                        try {
+                            String json = new String(offlineRegion.getMetadata(), MapBoxOfflineResourcesDownloader.JSON_CHARSET);
+                            JSONObject jsonObject = new JSONObject(json);
+                            if (jsonObject.has(MapBoxOfflineResourcesDownloader.METADATA_JSON_FIELD_REGION_NAME)) {
+                                String regionName = jsonObject.getString(MapBoxOfflineResourcesDownloader.METADATA_JSON_FIELD_REGION_NAME);
+                                if (mapName.equals(regionName)) {
+                                    offlineRegion.delete(new OfflineRegion.OfflineRegionDeleteCallback() {
+                                        @Override
+                                        public void onDelete() {
+                                            Log.i(TAG, "Map deleted successfully!");
+                                        }
+
+                                        @Override
+                                        public void onError(String error) {
+                                            Log.e(TAG, error);
+                                        }
+                                    });
+                                }
+                            }
+
+                        } catch (UnsupportedEncodingException | JSONException e) {
+                            Log.e(TAG, Log.getStackTraceString(e));
+                            // Just move to the next map
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onError(String error) {
+                Log.e(TAG, error);
+            }
+        });
     }
 
 }

--- a/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
+++ b/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
@@ -160,14 +160,6 @@ public class MapBoxOfflineResourcesDownloader {
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
             @Override
             public void onList(OfflineRegion[] offlineRegions) {
-                OfflineRegion similarOfflineRegion = getOfflineRegion(name, offlineRegions);
-                if (similarOfflineRegion != null) {
-                    if (onDownloadMapListener != null) {
-                        onDownloadMapListener.onError("Map Already Exists");
-                    }
-                    return;
-                }
-
                 // Download the map
                 byte[] metadata = new byte[0];
                 try {
@@ -566,6 +558,10 @@ public class MapBoxOfflineResourcesDownloader {
         }
 
         return null;
+    }
+
+    public OfflineManager getOfflineManager() {
+        return offlineManager;
     }
 
 }

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -119,7 +119,7 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
     public static final String PREFERENCE_MAPBOX_ACCESS_TOKEN = "MAPBOX ACCESS TOKEN";
 
     private String mapBoxAccessToken = "";
-    private String currentMapDownloadName = "";
+    private String currentMapDownloadName;
     private SERVICE_ACTION currentServiceAction;
     private MapBoxOfflineQueueTask currentMapBoxTask;
     private long currentMapDownloadId;

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -22,15 +22,12 @@ import android.text.format.Formatter;
 import android.util.Log;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.offline.OfflineManager;
 import com.mapbox.mapboxsdk.offline.OfflineRegion;
 import com.mapbox.mapboxsdk.offline.OfflineRegionError;
 import com.mapbox.mapboxsdk.offline.OfflineRegionStatus;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 
-import java.io.UnsupportedEncodingException;
 import java.text.DecimalFormat;
 
 import io.ona.kujaku.BuildConfig;

--- a/library/src/test/java/io/ona/kujaku/data/MapBoxDeleteTaskTest.java
+++ b/library/src/test/java/io/ona/kujaku/data/MapBoxDeleteTaskTest.java
@@ -20,22 +20,18 @@ import static org.junit.Assert.*;
 public class MapBoxDeleteTaskTest {
 
     @Test
-    public void constructorShouldCreateValidObject() {
+    public void constructorShouldCreateValidObject() throws JSONException, MalformedDataException {
         String mapName = "sample map name";
         String mapboxAccessToken = "90sd09jio(#@";
         JSONObject jsonObject = new JSONObject();
-        try {
-            jsonObject.put(MapBoxDeleteTask.MAP_NAME, mapName);
-            jsonObject.put(MapBoxDeleteTask.MAP_BOX_ACCESS_TOKEN, mapboxAccessToken);
 
-            MapBoxDeleteTask mapBoxDeleteTask = new MapBoxDeleteTask(jsonObject);
+        jsonObject.put(MapBoxDeleteTask.MAP_NAME, mapName);
+        jsonObject.put(MapBoxDeleteTask.MAP_BOX_ACCESS_TOKEN, mapboxAccessToken);
 
-            assertEquals(mapBoxDeleteTask.getMapName(), mapName);
-            assertEquals(mapBoxDeleteTask.getMapBoxAccessToken(), mapboxAccessToken);
-        } catch (JSONException | MalformedDataException e) {
-            e.printStackTrace();
-        }
+        MapBoxDeleteTask mapBoxDeleteTask = new MapBoxDeleteTask(jsonObject);
 
+        assertEquals(mapBoxDeleteTask.getMapName(), mapName);
+        assertEquals(mapBoxDeleteTask.getMapBoxAccessToken(), mapboxAccessToken);
     }
 
 }

--- a/library/src/test/java/io/ona/kujaku/data/MapBoxDownloadTaskTest.java
+++ b/library/src/test/java/io/ona/kujaku/data/MapBoxDownloadTaskTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.*;
 public class MapBoxDownloadTaskTest {
 
     @Test
-    public void constructorShouldCreateValidObject() {
+    public void constructorShouldCreateValidObject() throws JSONException, MalformedDataException {
         String mapName = "sample map name";
         String mapboxAccessToken = "90sd09jio(#@";
         String packageName = "package.com.io";
@@ -38,23 +38,27 @@ public class MapBoxDownloadTaskTest {
         bottomRightBound.setLongitude(Math.random() * 90);
 
         JSONObject jsonObject = new JSONObject();
-        try {
-            jsonObject.put(MapBoxDeleteTask.MAP_NAME, mapName);
-            jsonObject.put(MapBoxDeleteTask.MAP_BOX_ACCESS_TOKEN, mapboxAccessToken);
 
-            MapBoxDownloadTask mapBoxDownloadTask = new MapBoxDownloadTask(jsonObject);
+        jsonObject.put(MapBoxDownloadTask.MAP_NAME, mapName);
+        jsonObject.put(MapBoxDownloadTask.MAPBOX_ACCESS_TOKEN, mapboxAccessToken);
+        jsonObject.put(MapBoxDownloadTask.PACKAGE_NAME, packageName);
+        jsonObject.put(MapBoxDownloadTask.MAPBOX_STYLE_URL, mapboxStyleUrl);
+        jsonObject.put(MapBoxDownloadTask.MAX_ZOOM, maxZoom);
+        jsonObject.put(MapBoxDownloadTask.MIN_ZOOM, minZoom);
+        jsonObject.put(MapBoxDownloadTask.TOP_LEFT_BOUND, MapBoxDownloadTask.constructLatLngJSONObject(topLeftBound));
+        jsonObject.put(MapBoxDownloadTask.BOTTOM_RIGHT_BOUND, MapBoxDownloadTask.constructLatLngJSONObject(bottomRightBound));
 
-            assertEquals(mapName, mapBoxDownloadTask.getMapName());
-            assertEquals(mapboxAccessToken, mapBoxDownloadTask.getMapBoxAccessToken());
-            assertEquals(packageName, mapBoxDownloadTask.getPackageName());
-            assertEquals(mapboxStyleUrl, mapBoxDownloadTask.getMapBoxStyleUrl());
-            assertEquals(minZoom, mapBoxDownloadTask.getMinZoom(), 0.0);
-            assertEquals(maxZoom, mapBoxDownloadTask.getMaxZoom(), 0.0);
-            assertEquals(bottomRightBound, mapBoxDownloadTask.getBottomRightBound());
-            assertEquals(topLeftBound, mapBoxDownloadTask.getTopLeftBound());
-        } catch (JSONException | MalformedDataException e) {
-            e.printStackTrace();
-        }
+        MapBoxDownloadTask mapBoxDownloadTask = new MapBoxDownloadTask(jsonObject);
+
+        assertEquals(mapName, mapBoxDownloadTask.getMapName());
+        assertEquals(mapboxAccessToken, mapBoxDownloadTask.getMapBoxAccessToken());
+        assertEquals(packageName, mapBoxDownloadTask.getPackageName());
+        assertEquals(mapboxStyleUrl, mapBoxDownloadTask.getMapBoxStyleUrl());
+        assertEquals(minZoom, mapBoxDownloadTask.getMinZoom(), 0.0);
+        assertEquals(maxZoom, mapBoxDownloadTask.getMaxZoom(), 0.0);
+        assertEquals(bottomRightBound, mapBoxDownloadTask.getBottomRightBound());
+        assertEquals(topLeftBound, mapBoxDownloadTask.getTopLeftBound());
+
     }
 
 }

--- a/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
+++ b/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
@@ -47,12 +47,13 @@ import io.ona.kujaku.data.MapBoxDeleteTask;
 import io.ona.kujaku.data.MapBoxDownloadTask;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
 import io.ona.kujaku.listeners.OfflineRegionStatusCallback;
-import io.ona.kujaku.shadows.ShadowConnectivityReceiver;
-import io.ona.kujaku.shadows.ShadowMapBoxDeleteTask;
-import io.ona.kujaku.shadows.ShadowMapBoxDownloadTask;
-import io.ona.kujaku.shadows.ShadowOfflineManager;
-import io.ona.kujaku.shadows.ShadowRealm;
-import io.ona.kujaku.shadows.implementations.RealmDbTestImplementation;
+import io.ona.kujaku.test.shadows.ShadowConnectivityReceiver;
+import io.ona.kujaku.test.shadows.ShadowMapBoxDeleteTask;
+import io.ona.kujaku.test.shadows.ShadowMapBoxDownloadTask;
+import io.ona.kujaku.test.shadows.ShadowOfflineManager;
+import io.ona.kujaku.test.shadows.ShadowRealm;
+import io.ona.kujaku.test.shadows.ShadowRealmDatabase;
+import io.ona.kujaku.test.shadows.implementations.RealmDbTestImplementation;
 import io.ona.kujaku.utils.NumberFormatter;
 import utils.Constants;
 
@@ -74,7 +75,8 @@ import static org.junit.Assert.fail;
                 ShadowMapBoxDownloadTask.class,
                 ShadowConnectivityReceiver.class,
                 ShadowRealm.class,
-                ShadowOfflineManager.class
+                ShadowOfflineManager.class,
+                ShadowRealmDatabase.class
 })
 public class MapboxOfflineDownloaderServiceTest {
 

--- a/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
+++ b/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
@@ -178,7 +178,7 @@ public class MapboxOfflineDownloaderServiceTest {
         MapBoxOfflineQueueTask task = (MapBoxOfflineQueueTask) RealmDbTestImplementation.first();
 
         assertEquals(MapBoxOfflineQueueTask.TASK_TYPE_DELETE, task.getTaskType());
-        assertEquals(MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE, task.getTaskStatus());
+        assertEquals(MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED, task.getTaskStatus());
         assertTrue((calendar.getTimeInMillis() - task.getDateCreated().getTime()) < 1000);
         assertTrue((calendar.getTimeInMillis() - task.getDateUpdated().getTime()) < 1000);
 
@@ -206,7 +206,7 @@ public class MapboxOfflineDownloaderServiceTest {
         MapBoxOfflineQueueTask task = (MapBoxOfflineQueueTask) RealmDbTestImplementation.first();
 
         assertEquals(MapBoxOfflineQueueTask.TASK_TYPE_DOWNLOAD, task.getTaskType());
-        assertEquals(MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE, task.getTaskStatus());
+        assertEquals(MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED, task.getTaskStatus());
         assertTrue((calendar.getTimeInMillis() - task.getDateCreated().getTime()) < 1000);
         assertTrue((calendar.getTimeInMillis() - task.getDateUpdated().getTime()) < 1000);
 

--- a/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
+++ b/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CountDownLatch;
 import io.ona.kujaku.BuildConfig;
 import io.ona.kujaku.data.MapBoxDeleteTask;
 import io.ona.kujaku.data.MapBoxDownloadTask;
+import io.ona.kujaku.data.realm.RealmDatabase;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
 import io.ona.kujaku.listeners.OfflineRegionStatusCallback;
 import io.ona.kujaku.test.shadows.ShadowConnectivityReceiver;
@@ -112,13 +113,13 @@ public class MapboxOfflineDownloaderServiceTest {
     }
 
     @Test
-    public void persistsOfflineMapTaskShouldReturnFalseWhenGivenNullIntent() {
+    public void persistOfflineMapTaskShouldReturnFalseWhenGivenNullIntent() {
         Intent sampleExtra = null;
         assertEquals(false, mapboxOfflineDownloaderService.persistOfflineMapTask(sampleExtra));
     }
 
     @Test
-    public void persistsOfflineMapTaskShouldReturnFalseWhenGivenNullIntentExtras() {
+    public void persistOfflineMapTaskShouldReturnFalseWhenGivenNullIntentExtras() {
         Intent sampleExtra = new Intent();
         assertEquals(false, mapboxOfflineDownloaderService.persistOfflineMapTask(sampleExtra));
 
@@ -127,7 +128,7 @@ public class MapboxOfflineDownloaderServiceTest {
     }
 
     @Test
-    public void persistsOfflineMapTaskShouldReturnTrueWhenGivenValidDeleteTask() {
+    public void persistOfflineMapTaskShouldReturnTrueWhenGivenValidDeleteTask() {
         Intent sampleServiceIntent = createMapboxOfflineDownloaderServiceIntent();
         sampleServiceIntent = createSampleDeleteIntent(sampleServiceIntent);
 
@@ -135,10 +136,11 @@ public class MapboxOfflineDownloaderServiceTest {
     }
 
     @Test
-    public void persistsOfflineMapTaskShouldReturnTrueWhenGivenValidDownloadTask() {
+    public void persistOfflineMapTaskShouldReturnTrueWhenGivenValidDownloadTask() throws NoSuchFieldException, IllegalAccessException {
         Intent sampleServiceIntent = createMapboxOfflineDownloaderServiceIntent();
         sampleServiceIntent = createSampleDownloadIntent(sampleServiceIntent);
 
+        insertValueInPrivateField(mapboxOfflineDownloaderService, "realmDatabase", RealmDatabase.init(context));
         assertEquals(true, mapboxOfflineDownloaderService.persistOfflineMapTask(sampleServiceIntent));
     }
 
@@ -170,11 +172,12 @@ public class MapboxOfflineDownloaderServiceTest {
     }
 
     @Test
-    public void persistOfflineMapTaskShouldSaveQueueTaskWhenGivenValidDeleteTask() {
+    public void persistOfflineMapTaskShouldSaveQueueTaskWhenGivenValidDeleteTask() throws NoSuchFieldException, IllegalAccessException {
         Intent sampleServiceIntent = createMapboxOfflineDownloaderServiceIntent();
         sampleServiceIntent = createSampleDeleteIntent(sampleServiceIntent);
 
         Calendar calendar = Calendar.getInstance();
+        insertValueInPrivateField(mapboxOfflineDownloaderService, "realmDatabase", RealmDatabase.init(context));
         assertEquals(true, mapboxOfflineDownloaderService.persistOfflineMapTask(sampleServiceIntent));
 
         MapBoxOfflineQueueTask task = (MapBoxOfflineQueueTask) RealmDbTestImplementation.first();
@@ -198,11 +201,12 @@ public class MapboxOfflineDownloaderServiceTest {
     }
 
     @Test
-    public void persistOfflineMapTaskShouldSaveQueueTaskWhenGivenValidDownloadTask() {
+    public void persistOfflineMapTaskShouldSaveQueueTaskWhenGivenValidDownloadTask() throws NoSuchFieldException, IllegalAccessException {
         Intent sampleServiceIntent = createMapboxOfflineDownloaderServiceIntent();
         sampleServiceIntent = createSampleDownloadIntent(sampleServiceIntent);
 
         Calendar calendar = Calendar.getInstance();
+        insertValueInPrivateField(mapboxOfflineDownloaderService, "realmDatabase", RealmDatabase.init(context));
         assertEquals(true, mapboxOfflineDownloaderService.persistOfflineMapTask(sampleServiceIntent));
 
         MapBoxOfflineQueueTask task = (MapBoxOfflineQueueTask) RealmDbTestImplementation.first();
@@ -299,9 +303,9 @@ public class MapboxOfflineDownloaderServiceTest {
 
         insertValueInPrivateField(mapboxOfflineDownloaderService, "serviceHandler", new Handler(mapboxOfflineDownloaderService.getApplication().getMainLooper()));
 
-        Method method = mapboxOfflineDownloaderService.getClass().getDeclaredMethod("startDownloadProgressUpdater", null);
+        Method method = mapboxOfflineDownloaderService.getClass().getDeclaredMethod("startDownloadProgressUpdater");
         method.setAccessible(true);
-        method.invoke(mapboxOfflineDownloaderService, null);
+        method.invoke(mapboxOfflineDownloaderService);
 
         mapboxOfflineDownloaderService.onStatusChanged(incompleteOfflineRegionStatus, null);
         latch.await();
@@ -329,9 +333,9 @@ public class MapboxOfflineDownloaderServiceTest {
         assertEquals(contentTitle, shadowNotification.getContentTitle());
         assertEquals(contentText, shadowNotification.getContentText());
 
-        method = mapboxOfflineDownloaderService.getClass().getDeclaredMethod("stopDownloadProgressUpdater", null);
+        method = mapboxOfflineDownloaderService.getClass().getDeclaredMethod("stopDownloadProgressUpdater");
         method.setAccessible(true);
-        method.invoke(mapboxOfflineDownloaderService, null);
+        method.invoke(mapboxOfflineDownloaderService);
 
     }
 

--- a/library/src/test/java/io/ona/kujaku/shadows/ShadowMapBoxDeleteTask.java
+++ b/library/src/test/java/io/ona/kujaku/shadows/ShadowMapBoxDeleteTask.java
@@ -27,7 +27,7 @@ public class ShadowMapBoxDeleteTask {
             mapBoxOfflineQueueTask.setDateCreated(new Date());
             mapBoxOfflineQueueTask.setDateUpdated(new Date());
             mapBoxOfflineQueueTask.setTask(mapBoxDeleteTask.getJSONObject());
-            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE);
+            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED);
             mapBoxOfflineQueueTask.setTaskType(MapBoxOfflineQueueTask.TASK_TYPE_DELETE);
 
             RealmDbTestImplementation.add(mapBoxOfflineQueueTask.getId(), mapBoxOfflineQueueTask);

--- a/library/src/test/java/io/ona/kujaku/shadows/ShadowMapBoxDownloadTask.java
+++ b/library/src/test/java/io/ona/kujaku/shadows/ShadowMapBoxDownloadTask.java
@@ -27,7 +27,7 @@ public class ShadowMapBoxDownloadTask {
             mapBoxOfflineQueueTask.setDateCreated(new Date());
             mapBoxOfflineQueueTask.setDateUpdated(new Date());
             mapBoxOfflineQueueTask.setTask(mapBoxDownloadTask.getJSONObject());
-            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_INCOMPLETE);
+            mapBoxOfflineQueueTask.setTaskStatus(MapBoxOfflineQueueTask.TASK_STATUS_NOT_STARTED);
             mapBoxOfflineQueueTask.setTaskType(MapBoxOfflineQueueTask.TASK_TYPE_DOWNLOAD);
 
             RealmDbTestImplementation.add(mapBoxOfflineQueueTask.getId(), mapBoxOfflineQueueTask);

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowConnectivityReceiver.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowConnectivityReceiver.java
@@ -1,8 +1,7 @@
-package io.ona.kujaku.shadows;
+package io.ona.kujaku.test.shadows;
 
 import android.content.Context;
 
-import com.mapbox.mapboxsdk.net.ConnectivityListener;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 
 import org.robolectric.annotation.Implementation;

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowMapBoxDeleteTask.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowMapBoxDeleteTask.java
@@ -1,4 +1,4 @@
-package io.ona.kujaku.shadows;
+package io.ona.kujaku.test.shadows;
 
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -11,7 +11,7 @@ import java.util.Date;
 
 import io.ona.kujaku.data.MapBoxDeleteTask;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
-import io.ona.kujaku.shadows.implementations.RealmDbTestImplementation;
+import io.ona.kujaku.test.shadows.implementations.RealmDbTestImplementation;
 
 /**
  * Created by Ephraim Kigamba - ekigamba@ona.io on 22/12/2017.

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowMapBoxDownloadTask.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowMapBoxDownloadTask.java
@@ -1,4 +1,4 @@
-package io.ona.kujaku.shadows;
+package io.ona.kujaku.test.shadows;
 
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -11,7 +11,7 @@ import java.util.Date;
 
 import io.ona.kujaku.data.MapBoxDownloadTask;
 import io.ona.kujaku.data.realm.objects.MapBoxOfflineQueueTask;
-import io.ona.kujaku.shadows.implementations.RealmDbTestImplementation;
+import io.ona.kujaku.test.shadows.implementations.RealmDbTestImplementation;
 
 /**
  * Created by Ephraim Kigamba - ekigamba@ona.io on 22/12/2017.

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowOfflineManager.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowOfflineManager.java
@@ -1,4 +1,4 @@
-package io.ona.kujaku.shadows;
+package io.ona.kujaku.test.shadows;
 
 import android.content.Context;
 
@@ -16,10 +16,6 @@ import java.lang.reflect.InvocationTargetException;
 
 @Implements(OfflineManager.class)
 public class ShadowOfflineManager {
-
-    private void __constructor__() {
-        // Do nothing
-    }
 
     @Implementation
     public static synchronized OfflineManager getInstance(Context context) {

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowRealm.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowRealm.java
@@ -1,15 +1,11 @@
-package io.ona.kujaku.shadows;
+package io.ona.kujaku.test.shadows;
 
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
 import io.realm.Realm;
-import io.realm.internal.SharedRealm;
 
 /**
  * Created by Ephraim Kigamba - ekigamba@ona.io on 28/12/2017.

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowRealmDatabase.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowRealmDatabase.java
@@ -1,7 +1,6 @@
 package io.ona.kujaku.test.shadows;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
@@ -9,7 +8,6 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 import io.ona.kujaku.data.realm.RealmDatabase;
-import io.realm.Realm;
 
 /**
  * Created by Ephraim Kigamba - ekigamba@ona.io on 19/01/2018.

--- a/library/src/test/java/io/ona/kujaku/test/shadows/ShadowRealmDatabase.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/ShadowRealmDatabase.java
@@ -1,0 +1,34 @@
+package io.ona.kujaku.test.shadows;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import io.ona.kujaku.data.realm.RealmDatabase;
+import io.realm.Realm;
+
+/**
+ * Created by Ephraim Kigamba - ekigamba@ona.io on 19/01/2018.
+ */
+@Implements(RealmDatabase.class)
+public class ShadowRealmDatabase {
+
+    @Implementation
+    public static RealmDatabase init(Context context) {
+        PowerMockito.mockStatic(RealmDatabase.class);
+
+        RealmDatabase realmDatabase = Mockito.mock(RealmDatabase.class);
+
+        return realmDatabase;
+    }
+
+    @Implementation
+    public boolean deletePendingOfflineMapDownloadsWithSimilarNames(String mapName) {
+        // Do nothing
+        return true;
+    }
+}

--- a/library/src/test/java/io/ona/kujaku/test/shadows/implementations/RealmDbTestImplementation.java
+++ b/library/src/test/java/io/ona/kujaku/test/shadows/implementations/RealmDbTestImplementation.java
@@ -1,6 +1,5 @@
-package io.ona.kujaku.shadows.implementations;
+package io.ona.kujaku.test.shadows.implementations;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 

--- a/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
@@ -171,7 +171,7 @@ public class MainActivity extends AppCompatActivity {
             mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_MAPBOX_ACCESS_TOKEN, BuildConfig.MAPBOX_SDK_ACCESS_TOKEN);
             mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_SERVICE_ACTION, MapboxOfflineDownloaderService.SERVICE_ACTION.DOWNLOAD_MAP);
             mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_STYLE_URL, "mapbox://styles/ona/cj9jueph7034i2rphe0gp3o6m");
-            mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_MAP_UNIQUE_NAME, "Map Dw : " + (++lastMapDownloadId));
+            mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_MAP_UNIQUE_NAME, mapName);//"Map Dw : " + (++lastMapDownloadId));
             mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_MAX_ZOOM, 20.0);
             mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_MIN_ZOOM, 0.0);
             mapDownloadIntent.putExtra(Constants.PARCELABLE_KEY_TOP_LEFT_BOUND, new LatLng(37.7897, -119.5073));


### PR DESCRIPTION
Fixes #25

1. Make a call to the service for an offline map download
1. Delete all pending Offline Map Download tasks with: Similar name & STATUS_NOT_STARTED
1. Add the Offline Map to the task queue
1. When every Offline Map download task is complete, check if there are existing Mapbox Offline Maps downloaded with the same map name & delete them. Use the OfflineRegion Id to exclude the just completed download.