### PR TITLE
Fix issues related to PATH incompatibility

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'realm-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '0.2.4-89-2'
+version '0.2.4-89-3'
 project.version = this.version
 
 task sourceJar(type: Jar) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'realm-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '0.2.6-73-1'
+version '0.2.4-89-1'
 project.version = this.version
 
 task sourceJar(type: Jar) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'realm-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '0.2.4-89-1'
+version '0.2.4-89-2'
 project.version = this.version
 
 task sourceJar(type: Jar) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'realm-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '0.2.4-89-3'
+version '0.2.4-89-10'
 project.version = this.version
 
 task sourceJar(type: Jar) {

--- a/library/src/main/java/io/ona/kujaku/notifications/KujakuNotification.java
+++ b/library/src/main/java/io/ona/kujaku/notifications/KujakuNotification.java
@@ -82,8 +82,9 @@ abstract class KujakuNotification {
         return notificationChannel;
     }
 
+    @SuppressWarnings("deprecation")
     public NotificationCompat.Builder createNotification(String title, @Nullable String content) {
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, null)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
                 .setContentTitle(title)
                 .setSmallIcon(smallIcon);
 

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -185,7 +185,8 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
                     && extras.containsKey(Constants.PARCELABLE_KEY_MAPBOX_ACCESS_TOKEN)) {
                 final String mapUniqueName = extras.getString(Constants.PARCELABLE_KEY_MAP_UNIQUE_NAME);
                 mapBoxAccessToken = extras.getString(Constants.PARCELABLE_KEY_MAPBOX_ACCESS_TOKEN);
-                //saveAccessToken(mapboxAccessToken);
+
+                Mapbox.getInstance(this, mapBoxAccessToken);
 
                 MapBoxDownloadTask downloadTask = new MapBoxDownloadTask();
                 downloadTask.setMapName(mapUniqueName);


### PR DESCRIPTION
-  MapActivity crashing after offline map download started
- Notification not visible due to incompatibility with ZEIR support library version
- When an Offline Map Service DELETE_ACTION task is done, it should stop holding the queue

Fixes #89 