### PR TITLE
Add error notification for tile count limit exceeded

### DIFF
--- a/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
+++ b/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
@@ -374,6 +374,7 @@ public class MapBoxOfflineResourcesDownloader {
             @Override
             public void mapboxTileCountLimitExceeded(long limit) {
                 String errorMessage = "MapBox Tile count " + limit + " limit exceeded: Checkout https://www.mapbox.com/help/mobile-offline/ for more";
+                offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
                 Log.e(TAG, errorMessage);
                 if (onDownloadMapListener != null) {
                     onDownloadMapListener.onError(errorMessage);

--- a/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
+++ b/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
@@ -374,10 +374,9 @@ public class MapBoxOfflineResourcesDownloader {
             @Override
             public void mapboxTileCountLimitExceeded(long limit) {
                 String errorMessage = "MapBox Tile count " + limit + " limit exceeded: Checkout https://www.mapbox.com/help/mobile-offline/ for more";
-                offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
                 Log.e(TAG, errorMessage);
                 if (onDownloadMapListener != null) {
-                    onDownloadMapListener.onError(errorMessage);
+                    onDownloadMapListener.mapboxTileCountLimitExceeded(limit);
                 }
             }
         });

--- a/library/src/main/java/io/ona/kujaku/listeners/OnDownloadMapListener.java
+++ b/library/src/main/java/io/ona/kujaku/listeners/OnDownloadMapListener.java
@@ -18,12 +18,26 @@ public interface OnDownloadMapListener {
      * @param offlineRegionStatus The Offline Region's status
      * @param offlineRegion The Offline Region whose status was queried
      */
-    public void onStatusChanged(OfflineRegionStatus offlineRegionStatus, OfflineRegion offlineRegion);
+    void onStatusChanged(OfflineRegionStatus offlineRegionStatus, OfflineRegion offlineRegion);
 
     /**
      * Called when an error occurs during download or when an Offline download of a Region is requested
      *
      * @param error
      */
-    public void onError(String error);
+    void onError(String error);
+
+    /*
+     * Implement this method to be notified when the limit on the number of Mapbox
+     * tiles stored for offline regions has been reached.
+     *
+     * Once the limit has been reached, the SDK will not download further offline
+     * tiles from Mapbox APIs until existing tiles have been removed. Contact your
+     * Mapbox sales representative to raise the limit.
+     *
+     * This limit does not apply to non-Mapbox tile sources.
+     *
+     * This method will be executed on the main thread.
+     */
+    void mapboxTileCountLimitExceeded(long limit);
 }

--- a/library/src/main/java/io/ona/kujaku/notifications/CriticalDownloadErrorNotification.java
+++ b/library/src/main/java/io/ona/kujaku/notifications/CriticalDownloadErrorNotification.java
@@ -1,0 +1,45 @@
+package io.ona.kujaku.notifications;
+
+import android.app.NotificationManager;
+import android.content.Context;
+import android.graphics.Color;
+import android.support.v4.app.NotificationCompat;
+
+import io.ona.kujaku.R;
+
+/**
+ * Creates the appropriate channel for download error notifications.
+ * This notification displays critical download errors. Such errors include 404s and Mapbox tile
+ * count limit exceeded errors
+ * <p>
+ * Created by Ephraim Kigamba - ekigamba@ona.io on 04/12/2018
+ */
+
+public class CriticalDownloadErrorNotification extends KujakuNotification {
+
+    public static final String CHANNEL_ID = "KUJAKU_DOWNLOAD_ERROR_CHANNEL";
+    public static final int NOTIFICATION_COLOR = Color.RED;
+    public static final long[] VIBRATION_PATTERN = new long[]{200, 600, 300, 600};
+
+
+    public CriticalDownloadErrorNotification(Context context) {
+        setContext(context);
+        setSmallIcon(R.drawable.ic_stat_file_download);
+
+        createNotificationChannel(NotificationManager.IMPORTANCE_HIGH, context.getString(R.string.download_error_channel_name)
+                , CHANNEL_ID, context.getString(R.string.download_error_channel_description), NOTIFICATION_COLOR, VIBRATION_PATTERN);
+    }
+
+    /**
+     * Displays a download error notification given the title, content and notificationId
+     *
+     * @param title
+     * @param content
+     * @param notificationId
+     */
+    public void displayNotification(String title, String content, int notificationId) {
+        NotificationCompat.Builder notificationBuilder = createNotification(title, content);
+        notificationBuilder.setSmallIcon(android.R.drawable.ic_dialog_info);
+        displayNotification(notificationBuilder, notificationId);
+    }
+}

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -80,6 +80,9 @@ import io.ona.kujaku.utils.exceptions.OfflineMapDownloadException;
  * </p>
  * <p>
  * <p>
+ *This services uses notification ids from 80 to 2080. The application should therefore use notification ids from 2081
+ *
+ *
  * Created by Ephraim Kigamba - ekigamba@ona.io on 13/11/2017.
  */
 public class MapboxOfflineDownloaderService extends Service implements OfflineRegionObserver, OnDownloadMapListener {
@@ -115,8 +118,8 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
     public static final int REQUEST_ID_STOP_MAP_DOWNLOAD = 1;
 
     // Should persist across service instances but within the same app session
-    public static int LAST_DOWNLOAD_COMPLETE_NOTIFICATION_ID = 180;
-    public static int LAST_DOWNLOAD_ERROR_NOTIFICATION_ID = 280;
+    public static int LAST_DOWNLOAD_COMPLETE_NOTIFICATION_ID = 81;
+    public static int LAST_DOWNLOAD_ERROR_NOTIFICATION_ID = 1081;
 
     private boolean isPerformingTask = false;
 

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -401,11 +401,15 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
                 }
             });
         } else {
-            stopDownloadProgressUpdater();
-            NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-            notificationManager.cancel(PROGRESS_NOTIFICATION_ID);
-            stopSelf();
+            cleanupAndExit();
         }
+    }
+
+    private void cleanupAndExit() {
+        stopDownloadProgressUpdater();
+        NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        notificationManager.cancel(PROGRESS_NOTIFICATION_ID);
+        stopSelf();
     }
 
     /**
@@ -620,8 +624,8 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
         criticalDownloadErrorNotification.displayNotification(String.format(getString(R.string.error_occurred_download_map), currentMapDownloadName)
                 , String.format(getString(R.string.mapbox_tile_count_limit_of_exceeded), limit), LAST_DOWNLOAD_ERROR_NOTIFICATION_ID);
 
-        releaseQueueToPerformOtherJobs();
-        performNextTask();
+        // No other download can be performed and we should exit the service
+        cleanupAndExit();
     }
 
     private String getFriendlyFileSize(long bytes) {

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="notification_download_progress_content">Downloading: %1$s %%</string>
     <string name="notification_download_complete_title">Download for %1$s Map Complete!</string>
     <string name="notification_download_complete_content">Downloaded %1$s</string>
-    <string name="error_mapbox_tile_count_limit">MapBox Tile Count limit exceeded : %1$d while Downloading %2$s</string>
+    <string name="error_mapbox_tile_count_limit">MapBox Tile Count limit exceeded %1$d while Downloading %2$s</string>
     <string name="error_broadcast_message_format_part_reason">REASON : %1$s</string>
     <string name="error_broadcast_message_format_part_message">\nMESSAGE: %1$s</string>
     <string name="msg_could_not_find_your_location">Sorry but we could not get your location! Try Again</string>
@@ -21,6 +21,8 @@
     <string name="download_progress_channel_description">This channel shows notifications for offline map progress</string>
     <string name="download_complete_channel_name">Offline Map Download Complete</string>
     <string name="download_complete_channel_description">This channel shows notifications for complete offline map downloads</string>
+    <string name="download_error_channel_name">Offline Map Download Error</string>
+    <string name="download_error_channel_description">This channel shows notifications for critical offline map download errors</string>
     <string name="msg_location_retrieval_taking_longer_than_expected">Whoops! It seems that retrieving your location is going to take longer than expected!</string>
     <string name="done">DONE</string>
     <string name="cancel">CANCEL</string>
@@ -29,4 +31,6 @@
     <string name="current_location_btn_visibility">current_location_btn_visibility</string>
     <string name="location_permission">Location Permission</string>
     <string name="location_permission_reason">We need the location permission to focus on your location in the map</string>
+    <string name="error_occurred_download_map">Error occurred downloading %1$s</string>
+    <string name="mapbox_tile_count_limit_of_exceeded">Mapbox tile count limit of %1$d</string>
 </resources>

--- a/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
+++ b/library/src/test/java/io/ona/kujaku/services/MapboxOfflineDownloaderServiceTest.java
@@ -261,7 +261,7 @@ public class MapboxOfflineDownloaderServiceTest {
         latch.await();
 
         Intent intent = (Intent) resultsToCheck.get(0);
-        assertBroadcastResults(intent, MapboxOfflineDownloaderService.SERVICE_ACTION_RESULT.FAILED, mapName, "MapBox Tile Count limit exceeded : 60000 while Downloading " + mapName, MapboxOfflineDownloaderService.SERVICE_ACTION.DOWNLOAD_MAP);
+        assertBroadcastResults(intent, MapboxOfflineDownloaderService.SERVICE_ACTION_RESULT.FAILED, mapName, "MapBox Tile Count limit exceeded 60000 while Downloading " + mapName, MapboxOfflineDownloaderService.SERVICE_ACTION.DOWNLOAD_MAP);
     }
 
     @Test

--- a/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
@@ -67,7 +67,8 @@ public class MainActivity extends BaseNavigationDrawerActivity {
             Manifest.permission.READ_EXTERNAL_STORAGE
     };
 
-    private int lastNotificationId = 200;
+    // Kujaku library uses notification ids 80 to 2080
+    private int lastNotificationId = 2081;
     private final static String TAG = MainActivity.class.getSimpleName();
 
     private List<Point> points;

--- a/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
@@ -37,6 +37,7 @@ import io.ona.kujaku.domain.Point;
 import io.ona.kujaku.helpers.MapBoxStyleStorage;
 import io.ona.kujaku.helpers.MapBoxWebServiceApi;
 import io.ona.kujaku.listeners.OnFinishedListener;
+import io.ona.kujaku.notifications.CriticalDownloadErrorNotification;
 import io.ona.kujaku.sample.BuildConfig;
 import io.ona.kujaku.sample.MyApplication;
 import io.ona.kujaku.sample.R;

--- a/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
@@ -37,7 +37,6 @@ import io.ona.kujaku.domain.Point;
 import io.ona.kujaku.helpers.MapBoxStyleStorage;
 import io.ona.kujaku.helpers.MapBoxWebServiceApi;
 import io.ona.kujaku.listeners.OnFinishedListener;
-import io.ona.kujaku.notifications.CriticalDownloadErrorNotification;
 import io.ona.kujaku.sample.BuildConfig;
 import io.ona.kujaku.sample.MyApplication;
 import io.ona.kujaku.sample.R;

--- a/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
@@ -255,7 +255,12 @@ public class MainActivity extends BaseNavigationDrawerActivity {
 
                                 if (resultStatus.equals(MapboxOfflineDownloaderService.SERVICE_ACTION_RESULT.FAILED.name())) {
                                     String message = bundle.getString(MapboxOfflineDownloaderService.KEY_RESULT_MESSAGE);
-                                    showInfoNotification("Error occurred " + mapUniqueName + ":" + serviceAction.name(), message);
+
+                                    if (!TextUtils.isEmpty(message)) {
+                                        if (!message.contains("MapBox Tile Count limit exceeded")) {
+                                            showInfoNotification("Error occurred " + mapUniqueName + ":" + serviceAction.name(), message);
+                                        }
+                                    }
                                 }
                             }
                         } else {


### PR DESCRIPTION
Fixes #211 


See #211 for more


### How to test

1. Enter a download name in the first screen after openning the app. Do not enter any coordinates for it to download the default map
2. The map download tile count will be reached at around 2.34%. At this point, the error notification should appear