### PR TITLE
Fix offline map download resumption

### DIFF
--- a/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
+++ b/library/src/main/java/io/ona/kujaku/downloaders/MapBoxOfflineResourcesDownloader.java
@@ -55,6 +55,8 @@ public class MapBoxOfflineResourcesDownloader {
     protected OfflineManager offlineManager;
     private static final String TAG = MapBoxOfflineResourcesDownloader.class.getSimpleName();
 
+    private int connectivityReceiverActivationCounter = 0;
+
     // JSON encoding/decoding
     public static final String JSON_CHARSET = "UTF-8";
     public static final String METADATA_JSON_FIELD_REGION_NAME = "FIELD_REGION_NAME";
@@ -363,6 +365,7 @@ public class MapBoxOfflineResourcesDownloader {
     public void resumeMapDownload(@NonNull final OfflineRegion offlineRegion, final OnDownloadMapListener onDownloadMapListener) {
         ConnectivityReceiver.instance(context)
                 .activate();
+        increaseConnectivityReceiverActivationCounter();
         offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE);
         offlineRegion.setObserver(new OfflineRegion.OfflineRegionObserver() {
             @Override
@@ -370,6 +373,7 @@ public class MapBoxOfflineResourcesDownloader {
                 if (status.isComplete()) {
                     ConnectivityReceiver.instance(context)
                             .deactivate();
+                    decreaseConnectivityReceiverActivationCounter();
                 }
 
                 if (onDownloadMapListener != null) {
@@ -389,6 +393,7 @@ public class MapBoxOfflineResourcesDownloader {
             public void mapboxTileCountLimitExceeded(long limit) {
                 ConnectivityReceiver.instance(context)
                         .deactivate();
+                decreaseConnectivityReceiverActivationCounter();
                 String errorMessage = "MapBox Tile count " + limit + " limit exceeded: Checkout https://www.mapbox.com/help/mobile-offline/ for more";
                 Log.e(TAG, errorMessage);
                 if (onDownloadMapListener != null) {
@@ -635,4 +640,15 @@ public class MapBoxOfflineResourcesDownloader {
         });
     }
 
+    public void increaseConnectivityReceiverActivationCounter() {
+        connectivityReceiverActivationCounter++;
+    }
+
+    public void decreaseConnectivityReceiverActivationCounter() {
+        connectivityReceiverActivationCounter--;
+    }
+
+    public int getConnectivityReceiverActivationCounter() {
+        return connectivityReceiverActivationCounter;
+    }
 }

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -714,7 +714,11 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
     public void onDestroy() {
         super.onDestroy();
         stopDownloadProgressUpdater();
-        ConnectivityReceiver.instance(this)
-                .deactivate();
+
+        if (MapBoxOfflineResourcesDownloader.getInstance(this, BuildConfig.MAPBOX_SDK_ACCESS_TOKEN)
+                .getConnectivityReceiverActivationCounter() > 0) {
+            ConnectivityReceiver.instance(this)
+                    .deactivate();
+        }
     }
 }

--- a/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
+++ b/library/src/main/java/io/ona/kujaku/services/MapboxOfflineDownloaderService.java
@@ -18,6 +18,7 @@ import android.util.Log;
 
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.offline.OfflineRegion;
 import com.mapbox.mapboxsdk.offline.OfflineRegionError;
 import com.mapbox.mapboxsdk.offline.OfflineRegionStatus;
@@ -713,5 +714,7 @@ public class MapboxOfflineDownloaderService extends Service implements OfflineRe
     public void onDestroy() {
         super.onDestroy();
         stopDownloadProgressUpdater();
+        ConnectivityReceiver.instance(this)
+                .deactivate();
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -139,6 +139,7 @@ android {
 
 dependencies { configuration ->
 
+    //releaseTestKujakuImport(configuration)
     developmentKujakuModulesImport(this, configuration)
     implementation 'com.cocoahero.android:geojson:1.0.1@jar'
 

--- a/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/activities/MainActivity.java
@@ -510,7 +510,6 @@ public class MainActivity extends BaseNavigationDrawerActivity {
     }
 
     private void showInfoNotification(String title, String content) {
-        lastNotificationId++;
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
                 .setContentTitle(title)
                 .setContentText(content)


### PR DESCRIPTION
Fixes #194 

To test, my guess is turning off the internet(Wifi in case it's the source) and turning it back on after 5 mins and 11-13 mins to see if the download continues. It should resume within a few seconds of connecting back.

You should also monitor the log for error-tag logs from Mapbox. The only error-tag logs from Mapbox should be after disconnecting the internet. Error-tag logs while the internet is off indicates that Mapbox is still retrying the connection

More notes are on the issue