### PR TITLE
Increment library version to 0.8.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'realm-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '0.8.0'
+version '0.8.1'
 project.version = this.version
 
 task sourceJar(type: Jar) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -160,8 +160,8 @@ android {
 
 dependencies { configuration ->
 
-    //releaseTestKujakuImport(configuration)
-    developmentKujakuModulesImport(this, configuration)
+    releaseTestKujakuImport(configuration)
+    //developmentKujakuModulesImport(this, configuration)
     implementation 'com.cocoahero.android:geojson:1.0.1@jar'
 
     implementation "com.android.volley:volley:${volleyVersion}"
@@ -223,7 +223,7 @@ private static void developmentKujakuModulesImport(instance, configuration) {
 
 // This is used when making a release and you need to test that the published artifacts work in host applications OK
 private static void releaseTestKujakuImport(configuration) {
-    configuration.implementation 'io.ona.kujaku:library:0.8.0'
+    configuration.implementation 'io.ona.kujaku:library:0.8.1'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
- Increment library version
- Enable kujaku library release imports on the sample module

This enables Kujaku to load tiles locally by using a http server as seen in #322