### PR TITLE
Initialize location manager if null when getting last location

### DIFF
--- a/library/src/main/java/io/ona/kujaku/location/clients/AndroidGpsLocationClient.java
+++ b/library/src/main/java/io/ona/kujaku/location/clients/AndroidGpsLocationClient.java
@@ -128,6 +128,9 @@ public class AndroidGpsLocationClient extends BaseLocationClient {
     @Nullable
     @Override
     public Location getLastLocation() {
+        if (locationManager == null) {
+            locationManager = (LocationManager) context.getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
+        }
         Location lastLocationFromProvider = locationManager.getLastKnownLocation(getProvider());
         return lastLocationFromProvider != null && (lastLocation == null || lastLocationFromProvider.getTime() > lastLocation.getTime()) ? lastLocationFromProvider : lastLocation;
     }


### PR DESCRIPTION
Add a null check for `locationManager` when `getLastLocation` is called. 
Initialize `locationManager` if it is null