### PR TITLE
Add editBoundaryMode on DrawingManager

### DIFF
--- a/library/src/main/java/io/ona/kujaku/manager/DrawingManager.java
+++ b/library/src/main/java/io/ona/kujaku/manager/DrawingManager.java
@@ -57,6 +57,7 @@ public class DrawingManager {
     private boolean drawingEnabled;
 
     private FillBoundaryLayer currentFillBoundaryLayer;
+    private boolean editBoundaryMode;
 
     /**
      * Constructor
@@ -110,18 +111,21 @@ public class DrawingManager {
         mapboxMap.addOnMapClickListener(new MapboxMap.OnMapClickListener() {
             @Override
             public boolean onMapClick(@NonNull LatLng point) {
-                final PointF pixel = mapboxMap.getProjection().toScreenLocation(point);
-                List<Feature> features = mapboxMap.queryRenderedFeatures(pixel, (Expression) null, CircleManager.ID_GEOJSON_LAYER);
 
-                if (features.size() == 0 && drawingEnabled) {
-                    if (getCurrentKujakuCircle() != null) {
-                        unsetCurrentCircleDraggable();
-                    } else {
-                        drawCircle(point);
-                    }
+                if (!editBoundaryMode) {
+                    final PointF pixel = mapboxMap.getProjection().toScreenLocation(point);
+                    List<Feature> features = mapboxMap.queryRenderedFeatures(pixel, (Expression) null, CircleManager.ID_GEOJSON_LAYER);
 
-                    if (onDrawingCircleClickListener != null) {
-                        onDrawingCircleClickListener.onCircleNotClick(point);
+                    if (features.size() == 0 && drawingEnabled) {
+                        if (getCurrentKujakuCircle() != null) {
+                            unsetCurrentCircleDraggable();
+                        } else {
+                            drawCircle(point);
+                        }
+
+                        if (onDrawingCircleClickListener != null) {
+                            onDrawingCircleClickListener.onCircleNotClick(point);
+                        }
                     }
                 }
 
@@ -232,6 +236,11 @@ public class DrawingManager {
         }
 
         return false;
+    }
+
+    public boolean editBoundary(@NonNull FillBoundaryLayer fillBoundaryLayer) {
+        editBoundaryMode = true;
+        return startDrawing(fillBoundaryLayer);
     }
 
     /**


### PR DESCRIPTION
- This disables drawing outside the boundary
- This also adds an editBoundary method that enables the mode


~# Remaining~

- [ ] ~Enable faster adding a point between two points for more manipulation of the boundary eg. Adding a V between two circles/point requires adding an extra point between the two points and dragging the new point~

~Currently, adding a point between two points is possible but requires selecting the point next to the target location~

Moved to https://github.com/onaio/kujaku/issues/350