### PR TITLE
:recycle: Explicitly state exported flag on manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
         <service android:name=".services.TrackingService"
             android:label="Tracking Service">
         </service>
-        <receiver android:name=".receivers.KujakuNetworkChangeReceiver">
+        <receiver android:name=".receivers.KujakuNetworkChangeReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>
                 <action android:name="android.net.wifi.WIFI_STATE_CHANGED"/>


### PR DESCRIPTION
Android API 31 and above requires this.