### PR TITLE
Remove Multidex usages

### DIFF
--- a/configs.gradle
+++ b/configs.gradle
@@ -110,7 +110,6 @@ ext {
     mapboxAnnotationPluginVersion = "0.9.0"
     mapboxSdkVersion = "9.7.1"
     mapboxSdkTurfVersion = "7.2.0"
-    robolectricShadowsMultidexVersion = "4.13"
     robolectricVersion = "4.13"
     supportVersion = "1.0.0"
     volleyVersion = "1.2.1"
@@ -123,13 +122,12 @@ ext {
     mapboxSDKTurf = "com.mapbox.mapboxsdk:mapbox-sdk-turf:$mapboxSdkTurfVersion"
     mapboxAnnotationPlugin = "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:$mapboxAnnotationPluginVersion"
     robolectric = "org.robolectric:robolectric:$robolectricVersion"
-    robolectricShadowsMultidex = "org.robolectric:shadows-multidex:$robolectricShadowsMultidexVersion"
 }
 
 ext.mapboxDependencies = { instance, configuration ->
 
     configuration.implementation("com.mapbox.maps:android:$mapboxSdkVersion") {
-        transitive = true;
+        transitive = true
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-fragment'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,7 +42,6 @@ android {
         versionCode 1
         versionName this.version
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-        multiDexEnabled true
     }
 
     buildTypes {
@@ -57,11 +56,11 @@ android {
                         properties.containsKey("mapbox.sdk.token")) {
                     buildConfigField "String", "MAPBOX_SDK_ACCESS_TOKEN", "\"" + localProperties["mapbox.sdk.token"] + "\""
                 } else {
-                    println("One of the required config variables is not set in your local.properties");
+                    println("One of the required config variables is not set in your local.properties")
                     buildConfigField "String", "MAPBOX_SDK_ACCESS_TOKEN", "\"sample_key\""
                 }
             } else {
-                println("local.properties does not exist");
+                println("local.properties does not exist")
                 buildConfigField "String", "MAPBOX_SDK_ACCESS_TOKEN", "\"sample_key\""
             }
         }
@@ -77,11 +76,11 @@ android {
                         properties.containsKey("mapbox.sdk.token")) {
                     buildConfigField "String", "MAPBOX_SDK_ACCESS_TOKEN", "\"" + localProperties["mapbox.sdk.token"] + "\""
                 } else {
-                    println("One of the required config variables is not set in your local.properties");
+                    println("One of the required config variables is not set in your local.properties")
                     buildConfigField "String", "MAPBOX_SDK_ACCESS_TOKEN", "\"sample_key\""
                 }
             } else {
-                println("local.properties does not exist");
+                println("local.properties does not exist")
                 buildConfigField "String", "MAPBOX_SDK_ACCESS_TOKEN", "\"sample_key\""
 
             }
@@ -107,7 +106,7 @@ android {
 dependencies { configuration ->
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation (mapboxSDK) {
-        transitive = true;
+        transitive = true
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-fragment'
@@ -123,7 +122,7 @@ dependencies { configuration ->
     implementation (project(":utils")) {
     // Uncomment the line below when creating releases
     //implementation('io.ona.kujaku:utils:0.10.8-SNAPSHOT') {
-        transitive = true;
+        transitive = true
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
         exclude group: 'com.android.support', module: 'support-v4'
     }
@@ -133,8 +132,6 @@ dependencies { configuration ->
     implementation 'org.simpleframework:simple-xml:2.7.1'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.1.1'
     implementation 'com.jakewharton.timber:timber:5.0.1'
-
-    implementation 'androidx.multidex:multidex:2.0.1'
 
     customDependencies(this, configuration)
     appPermissionsDependencies(configuration)
@@ -147,7 +144,6 @@ private static void testDependencies(instance, configuration) {
     configuration.testImplementation instance.junit
 
     configuration.testImplementation instance.robolectric
-    configuration.testImplementation instance.robolectricShadowsMultidex
 
     configuration.testImplementation 'org.mockito:mockito-inline:5.2.0'
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,7 +28,6 @@ android {
         versionCode getMasterCommitCount()
         versionName getVersionName()
 
-        multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
@@ -95,8 +94,6 @@ dependencies { configuration ->
         exclude group: "com.android.support", module: "appcompat-v7"
     }
 
-    implementation 'androidx.multidex:multidex:2.0.1'
-
     testImplementation junit
     testImplementation robolectric
 }
@@ -111,7 +108,7 @@ private static void libraryModuleDevelopment(instance, configuration) {
     }
 
     configuration.implementation(instance.project(":utils")) {
-        transitive = true;
+        transitive = true
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'appcompat-v7'
@@ -119,7 +116,7 @@ private static void libraryModuleDevelopment(instance, configuration) {
     }
 
     configuration.implementation(instance.mapboxSDK) {
-        transitive = true;
+        transitive = true
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-fragment'

--- a/sample/src/main/java/io/ona/kujaku/sample/MyApplication.java
+++ b/sample/src/main/java/io/ona/kujaku/sample/MyApplication.java
@@ -1,6 +1,5 @@
 package io.ona.kujaku.sample;
 
-import androidx.multidex.MultiDexApplication;
 import io.ona.kujaku.KujakuLibrary;
 import io.ona.kujaku.sample.repository.KujakuRepository;
 import io.ona.kujaku.sample.repository.PointsRepository;
@@ -8,7 +7,9 @@ import timber.log.Timber;
 
 import static io.ona.kujaku.sample.util.Constants.DATABASE_NAME;
 
-public class MyApplication extends MultiDexApplication {
+import android.app.Application;
+
+public class MyApplication extends Application {
 
     private static final String TAG = MyApplication.class.getName();
 


### PR DESCRIPTION
Since the min SDK is 21, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l