### PR TITLE
Set max SDK version for storage permissions to 32.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 apply plugin: 'realm-android'
 apply plugin: 'maven-publish'
 
-version '0.10.7-SNAPSHOT'
+version '0.10.8-SNAPSHOT'
 
 project.version = this.version
 
@@ -122,7 +122,7 @@ dependencies { configuration ->
     // Comment the line below when creating releases - The line is for development of the library & utils
     implementation (project(":utils")) {
     // Uncomment the line below when creating releases
-    //implementation('io.ona.kujaku:utils:0.10.7-SNAPSHOT') {
+    //implementation('io.ona.kujaku:utils:0.10.8-SNAPSHOT') {
         transitive = true;
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
         exclude group: 'com.android.support', module: 'support-v4'

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'jacoco'
 
-version '0.10.7-SNAPSHOT'
+version '0.10.8-SNAPSHOT'
 project.version = this.version
 
 


### PR DESCRIPTION
Updated the maxSdkVersion for WRITE_EXTERNAL_STORAGE and READ_EXTERNAL_STORAGE permissions from 28 to 32 to allow compatibility with higher Android builds.